### PR TITLE
Feat/blockscout explorer links

### DIFF
--- a/packages/nouns-webapp/src/components/ChangeDelegatePannel/index.tsx
+++ b/packages/nouns-webapp/src/components/ChangeDelegatePannel/index.tsx
@@ -139,7 +139,7 @@ const ChangeDelegatePannel: React.FC<ChangeDelegatePannelProps> = props => {
         }
       />,
       <NavBarButton
-        buttonText={<Trans>View on Etherscan</Trans>}
+        buttonText={<Trans>View on Blockscout</Trans>}
         buttonStyle={NavBarButtonStyle.DELEGATE_PRIMARY}
         onClick={() => {
           window.open(etherscanTxLink, '_blank')?.focus();

--- a/packages/nouns-webapp/src/components/Footer/index.tsx
+++ b/packages/nouns-webapp/src/components/Footer/index.tsx
@@ -19,7 +19,7 @@ const Footer = () => {
           <Link text={<Trans>Discord</Trans>} url={discordURL} leavesPage={true} />
           <Link text={<Trans>Docs</Trans>} url={docsURL} leavesPage={true} />
           <Link text={<Trans>Twitter</Trans>} url={twitterURL} leavesPage={true} />
-          <Link text={<Trans>Etherscan</Trans>} url={etherscanURL} leavesPage={true} />
+          <Link text={<Trans>Blockscout</Trans>} url={etherscanURL} leavesPage={true} />
         </footer>
       </Container>
     </div>

--- a/packages/nouns-webapp/src/components/Holder/index.tsx
+++ b/packages/nouns-webapp/src/components/Holder/index.tsx
@@ -33,7 +33,6 @@ const Holder: React.FC<HolderProps> = props => {
   }
 
   const holder = data && data.noun.owner.id;
-  
 
   const nonNounderNounContent = (
     <a
@@ -43,9 +42,9 @@ const Holder: React.FC<HolderProps> = props => {
       className={classes.link}
     >
       <Tooltip
-        tip="View on Etherscan"
+        tip="View on Blockscout"
         tooltipContent={(tip: string) => {
-          return <Trans>View on Etherscan</Trans>;
+          return <Trans>View on Blockscout</Trans>;
         }}
         id="holder-etherscan-tooltip"
       >

--- a/packages/nouns-webapp/src/components/NavBar/index.tsx
+++ b/packages/nouns-webapp/src/components/NavBar/index.tsx
@@ -8,7 +8,7 @@ import { Nav, Navbar, Container } from 'react-bootstrap';
 import testnetNoun from '../../assets/testnet-noun.png';
 import config, { CHAIN_ID } from '../../config';
 import { utils } from 'ethers';
-import { buildEtherscanHoldingsLink } from '../../utils/etherscan';
+import { buildEtherscanAddressLink } from '../../utils/etherscan';
 import { ExternalURL, externalURL } from '../../utils/externalURL';
 import useLidoBalance from '../../hooks/useLidoBalance';
 import NavBarButton, { NavBarButtonStyle } from '../NavBarButton';
@@ -28,7 +28,7 @@ const NavBar = () => {
   const ethBalance = useEtherBalance(config.addresses.nounsDaoExecutor);
   const lidoBalanceAsETH = useLidoBalance();
   const treasuryBalance = ethBalance && lidoBalanceAsETH && ethBalance.add(lidoBalanceAsETH);
-  const daoEtherscanLink = buildEtherscanHoldingsLink(config.addresses.nounsDaoExecutor);
+  const daoEtherscanLink = buildEtherscanAddressLink(config.addresses.nounsDaoExecutor);
   const [isNavExpanded, setIsNavExpanded] = useState(false);
 
   const useStateBg =

--- a/packages/nouns-webapp/src/components/NavLocaleSwitcher/index.tsx
+++ b/packages/nouns-webapp/src/components/NavLocaleSwitcher/index.tsx
@@ -130,6 +130,7 @@ const NavLocaleSwitcher: React.FC<NavLocalSwitcherProps> = props => {
                 dropDownStyle,
                 classes.desktopLanguageButton,
               )}
+              key={locale}
               onClick={() => setLocale(locale)}
             >
               {LOCALE_LABEL[locale]}

--- a/packages/nouns-webapp/src/components/NounInfoCard/index.tsx
+++ b/packages/nouns-webapp/src/components/NounInfoCard/index.tsx
@@ -44,7 +44,7 @@ const NounInfoCard: React.FC<NounInfoCardProps> = props => {
         />
         <NounInfoRowButton
           iconImgSource={_AddressIcon}
-          btnText={<Trans>Etherscan</Trans>}
+          btnText={<Trans>Blockscout</Trans>}
           onClickHandler={etherscanButtonClickHandler}
         />
       </Col>

--- a/packages/nouns-webapp/src/components/NounInfoRowHolder/index.tsx
+++ b/packages/nouns-webapp/src/components/NounInfoRowHolder/index.tsx
@@ -46,9 +46,9 @@ const NounInfoRowHolder: React.FC<NounInfoRowHolderProps> = props => {
 
   return (
     <Tooltip
-      tip="View on Etherscan"
+      tip="View on Blockscout"
       tooltipContent={(tip: string) => {
-        return <Trans>View on Etherscan</Trans>;
+        return <Trans>View on Blockscout</Trans>;
       }}
       id="holder-etherscan-tooltip"
     >

--- a/packages/nouns-webapp/src/components/Winner/index.tsx
+++ b/packages/nouns-webapp/src/components/Winner/index.tsx
@@ -21,8 +21,8 @@ interface WinnerProps {
 const Winner: React.FC<WinnerProps> = props => {
   const { winner, isNounders, nounId } = props;
   const activeAccount = useAppSelector(state => state.account.activeAccount);
-  
-  console.log({winner, isNounders})
+
+  console.log({ winner, isNounders });
 
   const isCool = useAppSelector(state => state.application.isCoolBackground);
   const isMobile = isMobileScreen();
@@ -62,9 +62,9 @@ const Winner: React.FC<WinnerProps> = props => {
   ) : (
     <ShortAddress size={40} address={winner} avatar={true} />
   );
-  
-  const rewardRecipientString = rewardRecipient(nounId)
-  
+
+  const rewardRecipientString = rewardRecipient(nounId);
+
   const nounderNounContent = (
     <a
       href={buildEtherscanAddressLink(rewardRecipientString)}
@@ -73,9 +73,9 @@ const Winner: React.FC<WinnerProps> = props => {
       className={classes.link}
     >
       <Tooltip
-        tip="View on Etherscan"
+        tip="View on Blockscout"
         tooltipContent={(tip: string) => {
-          return <Trans>View on Etherscan</Trans>;
+          return <Trans>View on Blockscout</Trans>;
         }}
         id="holder-etherscan-tooltip"
       >

--- a/packages/nouns-webapp/src/components/profileEvent/event/DesktopDelegationEvent/index.tsx
+++ b/packages/nouns-webapp/src/components/profileEvent/event/DesktopDelegationEvent/index.tsx
@@ -30,12 +30,12 @@ const DesktopDelegationEvent: React.FC<DesktopDelegationEventProps> = props => {
             effect={'solid'}
             className={classes.delegateHover}
             getContent={dataTip => {
-              return <Trans>View on Etherscan</Trans>;
+              return <Trans>View on Blockscout</Trans>;
             }}
           />
           Delegate changed from
           <span
-            data-tip={`View on Etherscan`}
+            data-tip={`View on Blockscout`}
             onClick={() => window.open(buildEtherscanAddressLink(event.previousDelegate), '_blank')}
             data-for="view-on-etherscan-tooltip"
             className={classes.address}
@@ -45,7 +45,7 @@ const DesktopDelegationEvent: React.FC<DesktopDelegationEventProps> = props => {
           </span>{' '}
           to{' '}
           <span
-            data-tip={`View on Etherscan`}
+            data-tip={`View on Blockscout`}
             data-for="view-on-etherscan-tooltip"
             onClick={() => window.open(buildEtherscanAddressLink(event.newDelegate), '_blank')}
             className={classes.address}
@@ -61,10 +61,10 @@ const DesktopDelegationEvent: React.FC<DesktopDelegationEventProps> = props => {
             effect={'solid'}
             className={classes.delegateHover}
             getContent={dataTip => {
-              return <Trans>View on Etherscan</Trans>;
+              return <Trans>View on Blockscout</Trans>;
             }}
           />
-          <div data-tip={`View on Etherscan`} data-for="view-on-etherscan-txn-delegate-tooltip">
+          <div data-tip={`View on Blockscout`} data-for="view-on-etherscan-txn-delegate-tooltip">
             <TransactionHashPill transactionHash={event.transactionHash} />
           </div>
         </>

--- a/packages/nouns-webapp/src/components/profileEvent/event/DesktopNounWinEvent/index.tsx
+++ b/packages/nouns-webapp/src/components/profileEvent/event/DesktopNounWinEvent/index.tsx
@@ -31,14 +31,14 @@ const DesktopNounWinEvent: React.FC<DesktopNounWinEventProps> = props => {
             effect={'solid'}
             className={classes.delegateHover}
             getContent={dataTip => {
-              return <Trans>View on Etherscan</Trans>;
+              return <Trans>View on Blockscout</Trans>;
             }}
           />
           {isRewardNoun ? (
             <Trans>
               <span className={classes.bold}> Noun {event.nounId} </span> sent to{' '}
               <span
-                data-tip={`View on Etherscan`}
+                data-tip={`View on Blockscout`}
                 onClick={() => window.open(buildEtherscanAddressLink(event.winner), '_blank')}
                 data-for="view-on-etherscan-tooltip"
                 className={classes.address}
@@ -51,7 +51,7 @@ const DesktopNounWinEvent: React.FC<DesktopNounWinEventProps> = props => {
             <Trans>
               <span className={classes.bold}> Noun {event.nounId} </span> won by{' '}
               <span
-                data-tip={`View on Etherscan`}
+                data-tip={`View on Blockscout`}
                 onClick={() => window.open(buildEtherscanAddressLink(event.winner), '_blank')}
                 data-for="view-on-etherscan-tooltip"
                 className={classes.address}
@@ -70,12 +70,12 @@ const DesktopNounWinEvent: React.FC<DesktopNounWinEventProps> = props => {
             effect={'solid'}
             className={classes.delegateHover}
             getContent={dataTip => {
-              return <Trans>View on Etherscan</Trans>;
+              return <Trans>View on Blockscout</Trans>;
             }}
           />
           <div
             onClick={() => window.open(buildEtherscanTxLink(event.transactionHash), '_blank')}
-            data-tip={`View on Etherscan`}
+            data-tip={`View on Blockscout`}
             data-for="view-on-etherscan-txn-tooltip"
           >
             <TransactionHashPill transactionHash={event.transactionHash} />

--- a/packages/nouns-webapp/src/components/profileEvent/event/DesktopProposalVoteEvent/index.tsx
+++ b/packages/nouns-webapp/src/components/profileEvent/event/DesktopProposalVoteEvent/index.tsx
@@ -35,7 +35,7 @@ const DesktopProposalVoteEvent: React.FC<DesktopProposalVoteEventProps> = props 
             effect={'solid'}
             className={classes.delegateHover}
             getContent={dataTip => {
-              return <Trans>View on Etherscan</Trans>;
+              return <Trans>View on Blockscout</Trans>;
             }}
           />
           <ProposalVoteHeadline

--- a/packages/nouns-webapp/src/components/profileEvent/event/DesktopTransferEvent/index.tsx
+++ b/packages/nouns-webapp/src/components/profileEvent/event/DesktopTransferEvent/index.tsx
@@ -30,13 +30,13 @@ const DesktopTransferEvent: React.FC<DesktopTransferEventProps> = props => {
             effect={'solid'}
             className={classes.delegateHover}
             getContent={dataTip => {
-              return <Trans>View on Etherscan</Trans>;
+              return <Trans>View on Blockscout</Trans>;
             }}
           />
           <Trans>
             Holder changed from{' '}
             <span
-              data-tip={`View on Etherscan`}
+              data-tip={`View on Blockscout`}
               onClick={() => window.open(buildEtherscanAddressLink(event.from), '_blank')}
               data-for="view-on-etherscan-tooltip"
               className={classes.address}
@@ -62,12 +62,12 @@ const DesktopTransferEvent: React.FC<DesktopTransferEventProps> = props => {
             effect={'solid'}
             className={classes.delegateHover}
             getContent={dataTip => {
-              return <Trans>View on Etherscan</Trans>;
+              return <Trans>View on Blockscout</Trans>;
             }}
           />
           <div
             onClick={() => window.open(buildEtherscanTxLink(event.transactionHash), '_blank')}
-            data-tip={`View on Etherscan`}
+            data-tip={`View on Blockscout`}
             data-for="view-on-etherscan-txn-tooltip"
           >
             <TransactionHashPill transactionHash={event.transactionHash} />

--- a/packages/nouns-webapp/src/components/profileEvent/eventData/ProposalVoteHeadline/index.tsx
+++ b/packages/nouns-webapp/src/components/profileEvent/eventData/ProposalVoteHeadline/index.tsx
@@ -34,7 +34,7 @@ const ProposalVoteHeadline: React.FC<ProposalVoteHeadlineProps> = props => {
       />
       <span
         className={classes.voterLink}
-        data-tip={`View on Etherscan`}
+        data-tip={`View on Blockscout`}
         data-for="view-on-etherscan-tooltip"
         onClick={e => {
           // This is so that we don't navigate to the prop page on click the address

--- a/packages/nouns-webapp/src/locales/ja-JP.po
+++ b/packages/nouns-webapp/src/locales/ja-JP.po
@@ -399,8 +399,8 @@ msgstr "Nounの誕生日を取得できませんでした"
 
 #: src/components/Footer/index.tsx
 #: src/components/NounInfoCard/index.tsx
-msgid "Etherscan"
-msgstr "Etherscan"
+msgid "Blockscout"
+msgstr "Blockscout"
 
 #: src/pages/Vote/index.tsx
 msgid "Execute"
@@ -1008,7 +1008,7 @@ msgstr "すべての入札を表示"
 #: src/components/profileEvent/event/DesktopProposalVoteEvent/index.tsx
 #: src/components/profileEvent/event/DesktopTransferEvent/index.tsx
 #: src/components/profileEvent/event/DesktopTransferEvent/index.tsx
-msgid "View on Etherscan"
+msgid "View on Blockscout"
 msgstr "イーサスキャンで見る"
 
 #: src/components/Bid/index.tsx

--- a/packages/nouns-webapp/src/utils/etherscan.ts
+++ b/packages/nouns-webapp/src/utils/etherscan.ts
@@ -25,7 +25,7 @@ export const buildEtherscanAddressLink = (address: string): string => {
 };
 
 export const buildEtherscanTokenLink = (tokenContractAddress: string, tokenId: number): string => {
-  const path = `token/${tokenContractAddress}?a=${tokenId}`;
+  const path = `token/${tokenContractAddress}/instance/${tokenId}`;
   return new URL(path, BASE_URL).toString();
 };
 

--- a/packages/nouns-webapp/src/utils/etherscan.ts
+++ b/packages/nouns-webapp/src/utils/etherscan.ts
@@ -6,9 +6,9 @@ const getBaseURL = (network: ChainId) => {
     case ChainId.Rinkeby:
       return 'https://rinkeby.etherscan.io/';
     case ChainId.Goerli:
-      return 'https://api-goerli.etherscan.io/';
+      return 'https://eth-goerli.blockscout.com//';
     default:
-      return 'https://etherscan.io/';
+      return 'https://eth.blockscout.com/';
   }
 };
 
@@ -26,11 +26,6 @@ export const buildEtherscanAddressLink = (address: string): string => {
 
 export const buildEtherscanTokenLink = (tokenContractAddress: string, tokenId: number): string => {
   const path = `token/${tokenContractAddress}?a=${tokenId}`;
-  return new URL(path, BASE_URL).toString();
-};
-
-export const buildEtherscanHoldingsLink = (address: string): string => {
-  const path = `tokenholdings?a=${address}`;
   return new URL(path, BASE_URL).toString();
 };
 


### PR DESCRIPTION
Changes the etherscan urls to blockscout urls.
- tx/
- address/
- token/

There was no direct equivalent to the token holdings link used in the top left nav:
https://etherscan.io/tokenholdings?a=0x553826Cb0D0Ee63155920F42b4E60aaE6607DFCB

so sent this directly to the token page, has similar data
https://eth.blockscout.com/address/0x553826Cb0D0Ee63155920F42b4E60aaE6607DFCB

Also updates all link/button lables from etherscan to blockscount.